### PR TITLE
fix: eliminar console.log de debug y useEffect duplicado en procedimientoTramite

### DIFF
--- a/Client/src/pages/Superadmin/Tramites/procedimientoTramite.jsx
+++ b/Client/src/pages/Superadmin/Tramites/procedimientoTramite.jsx
@@ -117,17 +117,6 @@ function ProcedimientoTramite() {
     getAlumnoProceso(setAlumnoProceso);
   }, []);
 
-  useEffect(() => {
-    getAlumnoProceso(setAlumnoProceso);
-}, []);
-
-useEffect(() => {
-    if (alumnoprocesoList.length > 0) {
-        console.log("Datos de alumnoproceso:", alumnoprocesoList[0]); // Ver el primer objeto
-        console.log("Claves del objeto:", Object.keys(alumnoprocesoList[0])); // Verificar nombres de las claves
-    }
-}, [alumnoprocesoList]);
-
 
   if (!idAlumnoTramiteParam) {
     return <h5 className="text-danger text-center mt-4">⚠ Acceso denegado: Falta seleccionar un trámite.</h5>;


### PR DESCRIPTION
## Summary

- Se eliminó un `useEffect` que siempre loggeaba `alumnoprocesoList[0]` en la consola, causando confusión al mostrar siempre los datos del primer alumno (ENRIQUE JAHIR DIAZ GONZALEZ) sin importar qué alumno se seleccionara.
- Se eliminó un `useEffect` duplicado que llamaba a `getAlumnoProceso` dos veces innecesariamente.

## Detalle del problema

El log de debug en `procedimientoTramite.jsx` usaba `alumnoprocesoList[0]` (índice fijo) en lugar de los datos del alumno filtrado, haciendo creer que el componente siempre cargaba al mismo alumno. La lógica de filtrado con `filteredData` funcionaba correctamente; el problema era exclusivamente visual en la consola.

## Test plan

- [ ] Abrir la vista de trámites y hacer clic en "Proceso" de distintos alumnos
- [ ] Verificar que la pantalla muestra correctamente los datos del alumno seleccionado
- [ ] Confirmar que la consola ya no muestra logs de debug con datos de alumnos

🤖 Generated with [Claude Code](https://claude.com/claude-code)